### PR TITLE
[FIX] Restore lost table style line

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthbar/peak-style",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Base and Pattern styles for Peak Design System",
   "main": "scss/index.scss",
   "scripts": {

--- a/scss/base/reset.scss
+++ b/scss/base/reset.scss
@@ -63,6 +63,7 @@ q:before, q:after {
 }
 table {
   border-collapse: collapse;
+  border-spacing: 0;
   display: table;
   table-layout: auto;
   text-align: left;


### PR DESCRIPTION
### Summary

Peak table styles were originally supposed to be global. We did a bunch of fixes to make this work.
Then we decided they wouldn't be global. We tried to roll back any fixes that would now cause problems.
Somewhere along the way this line should have been restored but wasn't. The result was poor appearance at https://www.wealthbar.com/app/statements

### QA

https://www.wealthbar.com/app/statements should no longer have that extra gutter between table cells. It should look like it used to.

### Submitter Checklist

- [x] Demo new or changed functionality to stakeholders
- [x] Perform self-review (see reviewer checklist)
- [x] Annotate MR with comments for reviewer
- [ ] Assign a team member who should specifically review this code
- [ ] Address reviewer feedback, if any, and assign back to reviewer

### Reviewer Checklist:

- [ ] Version bump in package.json
- [ ] Visually review significant UI changes
- [ ] Assign @pez-wb as reviewer if needed
- [ ] Assign back to submitter with feedback
