### PR TITLE
rollback recent change to fix header in documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthbar/peak-style",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Base and Pattern styles for Peak Design System",
   "main": "scss/index.scss",
   "scripts": {

--- a/scss/patterns/cards.scss
+++ b/scss/patterns/cards.scss
@@ -7,7 +7,7 @@
 
   &.shadow { box-shadow: $box-shadow; }
 
-  > header,
+  // > header,
   > article,
   > footer,
   .card-content {


### PR DESCRIPTION
### Summary

A new style rule was added in 2.3.0, with the unintended consequence of messing up the headings on the Documents page:

bad:
![Screen Shot 2020-07-31 at 1 56 52 PM](https://user-images.githubusercontent.com/53101170/89076756-be709c80-d335-11ea-92e1-c6ee26b740ec.png)


Good:
![Screen Shot 2020-07-31 at 1 56 02 PM](https://user-images.githubusercontent.com/53101170/89076707-a3059180-d335-11ea-9238-bbb2ea6f0576.png)


### Submitter Checklist:

- [x] Demo new or changed functionality to stakeholders
- [x] Perform self-review (see reviewer checklist)
- [x] Annotate MR with comments for reviewer
- [ ] Assign a team member who should specifically review this code
- [ ] Address reviewer feedback, if any, and assign back to reviewer

### Reviewer Checklist:

- [ ] Version bump in package.json
- [ ] Visually review significant UI changes
- [ ] Assign @pez-wb as reviewer if needed
- [ ] Assign back to submitter with feedback
