### PR TITLE
Improve .neg and .pos classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthbar/peak-style",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Base and Pattern styles for Peak Design System",
   "main": "scss/index.scss",
   "scripts": {

--- a/scss/base/typography.scss
+++ b/scss/base/typography.scss
@@ -92,8 +92,14 @@ sup {
 
 strong, b, .strong { font-weight: bold; }
 em, i, var, .em { font-style: normal; }
-del, .neg { color: $ruby-500; }
-.pos { color: $primary-500; }
+del, .neg {
+  color: $neg-500;
+  fill: $neg-500;
+}
+.pos {
+  color: $pos-500;
+  fill: $pos-500;
+}
 
 .tab-numbers { font-feature-settings: $tab-numbers; }
 .subtle { color: rgba($neutral-900, 0.77); }


### PR DESCRIPTION
### Summary

The `.neg` and `.pos` classes were not properly using the corresponding colours.
While I was at it, I added `fill` rules so that these classes can also be used on SVGs.

### Submitter Checklist:

- [ ] Demo new or changed functionality to stakeholders
- [x] Perform self-review (see reviewer checklist)
- [x] Annotate MR with comments for reviewer
- [ ] Document any new patterns or features on [peak-design-system](https://github.com/WealthBar/peak-design-system)
- [x] Assign a team member who should specifically review this code
- [ ] Address reviewer feedback, if any, and assign back to reviewer

### Reviewer Checklist:

- [ ] Version bump in package.json
- [ ] Visually review significant UI changes
- [ ] Assign @pez-wb as reviewer if needed
- [ ] Assign back to submitter with feedback
