### PR TITLE
Update NPM token based auth to OIDC auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
 
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build_commit:
     name: Build and commit CSS
@@ -31,14 +36,19 @@ jobs:
     runs-on: ubuntu-18.04
     needs: build_commit
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Ensure npm 11.5.1 or later is installed
+      - name: Update npm
+        run: npm install -g npm@latest
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npm publish
       - name: Checkout repo
         uses: actions/checkout@v2
-
-      - name: Configure NPM
-        run: |
-          npm install
-          npm test
-      - name: Publish npm package
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthbar/peak-style",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Base and Pattern styles for Peak Design System",
   "contributors": ["Andrew Pengelly", "Sharifa Samuels", "Travis Rempel", "James Payne"],
   "license": "MIT",


### PR DESCRIPTION
### Summary
As of October 19th NPM has reduced the time of personal tokens to 7 days this would require setting them up each time we need to publish really removing any usefulness of automating the process. 

I migrated the authentication method to OIDC OpenID Connect which should resolve the personal token timeouts. 

### Submitter Checklist:

<!-- Remove anything that is not relevant -->
- [ ] Address reviewer feedback, if any, and assign back to reviewer

### Reviewer Checklist:

<!-- Remove anything that is not relevant -->

- [ ] Version bump in package.json
- [ ] Assign back to submitter with feedback
